### PR TITLE
Set buffer size

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -21,14 +21,18 @@ http {
         ssl_prefer_server_ciphers on;
 
         location / {
+            proxy_pass  http://${TARGET_HOST}:${TARGET_PORT};
+            
             proxy_set_header Host              $host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Host  $host;
-
-            proxy_pass http://${TARGET_HOST}:${TARGET_PORT};
-            proxy_set_header  X-Real-IP $remote_addr;
+            proxy_set_header                   X-Real-IP $remote_addr;
+            
+            proxy_buffer_size        128k;
+            proxy_buffers            4 256k;
+            proxy_busy_buffers_size  256k;
         }
     }
 }


### PR DESCRIPTION
I was proxying an ASP.NET Core application, and the headers returned by azure ad are too big. This was the fix:

https://www.howtoforge.com/nginx-upstream-sent-too-big-header-while-reading-response-header-from-upstream