### PR TITLE
Allow you to specify the SSL Port.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM alpine:3.7
 
+ENV SSL_PORT=443
+
 RUN apk update && apk add nginx openssl gettext
 
 ADD add_self_signed_certs.sh /
 ADD nginx.conf.template /
 ADD configure_nginx.sh /
 
-EXPOSE 443
+EXPOSE ${SSL_PORT}
 
 ENTRYPOINT ["/configure_nginx.sh"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The following environment variables configure nginx:
 - ``TARGET_PORT``: target port for the reverse proxy (default value: ``80``)
 - ``TARGET_HOST``: target host for the reverse proxy (default value: ``proxyapp``)
 - ``CLIENT_MAX_BODY_SIZE``: maximum size of client uploads (default value: ``20M``)
+  ``SSL_PORT``: port ngnix SSL proxy listens on
 
 ## Certificates and CA location
 

--- a/configure_nginx.sh
+++ b/configure_nginx.sh
@@ -3,6 +3,7 @@
 export TARGET_PORT=${TARGET_PORT:-80}
 export TARGET_HOST=${TARGET_HOST:-proxyapp}
 export CLIENT_MAX_BODY_SIZE=${CLIENT_MAX_BODY_SIZE:-20M}
+export SSL_PORT=$SSL_PORT:-443}
 
 # Hack to avoid breaking nginx.conf
 export host='$host' remote_addr='$remote_addr' proxy_add_x_forwarded_for='$proxy_add_x_forwarded_for' scheme='$scheme' remote_addr='$remote_addr'

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -8,7 +8,7 @@ http {
     sendfile on;
 
     server {
-        listen 443;
+        listen ${SSL_PORT};
 
         client_max_body_size ${CLIENT_MAX_BODY_SIZE};
         ssl_certificate     /etc/nginx/certs/cert.pem;

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 targetDocker="bixel"
-port=443
+port=$SSL_PORT
 targetPort=80
 
 while getopts ':d::p::t:' opt; do


### PR DESCRIPTION
In order for the X-Forwarded-For to have the proper port number (if the port isn't 443), I need to expose the proxy on the same port that docker-compose.yml redirects it to. 

BTW My use case is here: https://github.com/justaprogrammer/JustAProgrammer.AspNetCore.Auth.SslProxy

**I can't build this to test it** because I'm on docker for windows, and I get the following when I build the image (even master):

```
PS C:\Users\Justin Dearing\source\repos\docker-ssl-proxy> docker build . -t docker-ssl-proxy
Sending build context to Docker daemon  131.6kB
Step 1/7 : FROM alpine:3.7
 ---> 3fd9065eaf02
Step 2/7 : RUN apk update && apk add nginx openssl gettext
 ---> Running in 80356d8716b2

. . .

SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added
to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
```

And then when I run it I get:

```
PS C:\Users\Justin Dearing\source\repos\docker-ssl-proxy> docker run docker-ssl-proxy
/bin/sh: illegal option -
PS C:\Users\Justin Dearing\source\repos\docker-ssl-proxy>
```

