### PR TITLE
Update default SSL cert to v3 for MacOS 10.15 / iOS 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV SSL_PORT=443
 RUN apk add --no-cache nginx openssl gettext
 
 ADD add_self_signed_certs.sh /
+ADD openssl.cnf.template /
 ADD nginx.conf.template /
 ADD configure_nginx.sh /
 

--- a/add_self_signed_certs.sh
+++ b/add_self_signed_certs.sh
@@ -2,19 +2,23 @@
 
 DOMAIN=${DOMAIN:-www.example.com}
 OUTPUT_DIR=/etc/nginx/certs
-CA_DIR=/etc/nginx/ca
 
-mkdir -p $OUTPUT_DIR $CA_DIR
+mkdir -p $OUTPUT_DIR
 
-# Generate the root CA if it doesn't exist
-if [ ! -f ${CA_DIR}/rootCA.crt ]; then
-	openssl genrsa -out ${CA_DIR}/rootCA.key 2048
-	openssl req -x509 -new -nodes -key ${CA_DIR}/rootCA.key -sha256 -days 1024 -subj "/C=US/ST=Denial/L=Springfield/O=DisRoot/CN=CompanyRoot" -out ${CA_DIR}/rootCA.crt
-fi
+REPLACEABLE='$DOMAIN'
+
+envsubst $REPLACEABLE < /openssl.cnf.template > /openssl.cnf
 
 if [ ! -f ${OUTPUT_DIR}/key.pem ]; then
+  echo "SSL Certificate not found. Generating self-signed certficiate..."
+
     # Generate the certificate
-    openssl genrsa -out ${OUTPUT_DIR}/key.pem 2048
-    openssl req -new -sha256 -key ${OUTPUT_DIR}/key.pem -nodes -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=${DOMAIN}" -out ${OUTPUT_DIR}/csr.pem
-    openssl x509 -req -in ${OUTPUT_DIR}/csr.pem -CA ${CA_DIR}/rootCA.crt -CAkey ${CA_DIR}/rootCA.key -CAcreateserial -out ${OUTPUT_DIR}/cert.pem
+    openssl req -x509 -nodes \
+      -newkey rsa:2048 \
+      -keyout ${OUTPUT_DIR}/key.pem \
+      -out ${OUTPUT_DIR}/cert.pem \
+      -days 825 \
+      -config /openssl.cnf \
+      -extensions v3_req \
+      -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=${DOMAIN}"
 fi

--- a/openssl.cnf.template
+++ b/openssl.cnf.template
@@ -1,0 +1,16 @@
+[req]
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+countryName = Country Name (2 letter code)
+countryName_default = US
+localityName = Locality Name (eg, city)
+organizationalUnitName = Organizational Unit Name (eg, section)
+
+[v3_req] 
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1   = ${DOMAIN}


### PR DESCRIPTION
This PR will change the way default certs are created to include SSL v3 certs with the ExtendedKeyUsage extension and Subject Alternative Name. This should make the certs more compatible in the future.

Fixes #19.