### PR TITLE
Disable TLSv1.0 and TLSv1.1

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -20,7 +20,7 @@ http {
         ssl_certificate_key /etc/nginx/certs/key.pem;
 
         ssl_session_cache  builtin:1000  shared:SSL:10m;
-        ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+        ssl_protocols  TLSv1.2;
         ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
         ssl_prefer_server_ciphers on;
 


### PR DESCRIPTION
They are both considered insecure and were deprecated by all major browsers. Nowadays we have TLSv1.2 and TLSv1.3 that we can use safely.