### PR TITLE
Add error logging to standard out

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -2,7 +2,7 @@ worker_processes 1;
 pid /run/nginx.pid;
 daemon off;
 
-error_log /dev/stdout info;
+error_log stderr info;
 
 events { worker_connections 1024; }
 

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -2,6 +2,8 @@ worker_processes 1;
 pid /run/nginx.pid;
 daemon off;
 
+error_log /dev/stdout info;
+
 events { worker_connections 1024; }
 
 http {


### PR DESCRIPTION
This will make important nginx log messages appear in the docker log. Currently it's completely silent which makes debugging bad configuration very hard.