### PR TITLE
Websocket connect

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -30,7 +30,7 @@ http {
 
         location / {
             proxy_pass  ${TARGET_SCHEME}://${TARGET_HOST}:${TARGET_PORT};
-
+            proxy_http_version 1.1;
             proxy_set_header Host              ${TARGET_HOST_HEADER};
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Hi this pr is to add the http proxy version for a websocket. Since I added proxy_http_version 1.1; websocket with ssl works for me, without that it doesn't.
Reference: https://www.nginx.com/blog/websocket-nginx/
