### PR TITLE
Allow additional X509v3 Subject Alternative Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Builds a basic nginx server that proxies incoming SSL calls to a target host
 The following environment variables configure nginx:
 
 - ``DOMAIN``: domain in the SSL certificate (default value: ``www.example.com``)
+- ``ALT_NAMES``: optional comma-separated list of alternative domain names (e.g: ``example.net,example.tv``)
 - ``TARGET_PORT``: target port for the reverse proxy (default value: ``80``)
 - ``TARGET_HOST``: target host for the reverse proxy (default value: ``proxyapp``)
 - ``TARGET_HOST_HEADER``: value to be used as the Host header when sending

--- a/add_self_signed_certs.sh
+++ b/add_self_signed_certs.sh
@@ -15,9 +15,6 @@ if [ ! -f ${OUTPUT_DIR}/key.pem ]; then
   # Generate subject alternative names if specified
   if [ ! -z "$ALT_NAMES" ]; then
 
-    # Remove errant spaces
-    ALT_NAMES="${ALT_NAMES// /}"
-
     # The base domain is already #1 so $I starts at #2
     I=2
     for ALT_NAME in ${ALT_NAMES//,/ }; do

--- a/add_self_signed_certs.sh
+++ b/add_self_signed_certs.sh
@@ -12,6 +12,20 @@ envsubst $REPLACEABLE < /openssl.cnf.template > /openssl.cnf
 if [ ! -f ${OUTPUT_DIR}/key.pem ]; then
   echo "SSL Certificate not found. Generating self-signed certficiate..."
 
+  # Generate subject alternative names if specified
+  if [ ! -z "$ALT_NAMES" ]; then
+
+    # Remove errant spaces
+    ALT_NAMES="${ALT_NAMES// /}"
+
+    # The base domain is already #1 so $I starts at #2
+    I=2
+    for ALT_NAME in ${ALT_NAMES//,/ }; do
+      echo "DNS.$(( I++ ))   = ${ALT_NAME}" >> /openssl.cnf
+    done
+
+  fi
+
     # Generate the certificate
     openssl req -x509 -nodes \
       -newkey rsa:2048 \


### PR DESCRIPTION
You can specify a comma-separated list of alternative domain names to bundle into the certificate via the ALT_NAMES environment variable.

Closes #119.