### PR TITLE
Properly synchronise CA certificate creation when multiple instances use a shared CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,27 @@ The SSL certificate is generated using a own-ROOT-ca that is available in the
 directory ``/etc/nginx/ca``, you may use Docker volumes to share the CAs with
 other containers, so they can trust the installed certificate.
 
-You can also install the shared CA cert on your workstation to automatically
-trust all of your docker-ssl-proxy services in your browser, without having
-to override security warnings each time you visit or restart the services.
+Your container may initialise faster than docker-ssl-proxy; therefore your
+start-up script should wait until the CA-cert has a non-zero size before
+attempting to use it.
 
-It may be wise if using a shared CA volume with multiple docker-ssl-proxys
-to let one finish initializing before the others; to avoid a conceivable race
-condition where they write over each others' CA keys. Pick any proxy instance
-and make the others ``depends_on`` it.
+### Import CA cert into container
+Example for Debian / Ubuntu, assuming volume mount of `./https-proxy-ca:/etc/ssl/shared-ca`:
+```
+cp /etc/ssl/shared-ca/rootCA.crt /usr/local/share/ca-certificates/
+update-ca-certificates
+```
+
+### Import CA cert onto workstation
+
+You can also install the shared CA cert on your workstation to automatically
+trust all of your docker-ssl-proxy services in your browser, without having to
+override security warnings each time you visit or restart the services.
+
+Example for Mac OSX:
+```
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain https-proxy-ca/rootCA.crt
+```
 
 ## Using own Certificate
 


### PR DESCRIPTION
At present, if multiple docker-ssl-proxy containers are instantiated, there is a potential race condition where two or more attempt to generate the rootCA.crt at the same time, potentially leading to different containers importing and trusting totally different CA certs.

This change uses the shell flock (file-lock) mechanism to lock the rootCA.crt file before proceeding with certificate creation. The first container to get the lock will generate the certificate, while subsequent containers will block until the file lock is released. At this point, they will see that rootCA.crt already exists, will realise they were late to the party, and will skip certificate (re-)generation.

This has not been tested with Docker Swarm or NFS volume mounts, which may require specific mount options for flock to work properly.

I've also added examples for importing the CA certificate into Debian / Ubuntu, and into Mac OSX, in the readme.